### PR TITLE
python setup.py build / test fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
         - PIP_INSTALL='pip install'
         - BOTTLENECK=no
         - YT=no
+        - PYAST=no
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -67,6 +68,10 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.5 SETUP_CMD='test'
 
+        # try pyast:
+        - python: 2.7
+          env: PYAST=yes
+
 before_install:
 
     # Use utf8 encoding. Should be default, but this is insurance against
@@ -101,7 +106,7 @@ install:
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
     # install since this ensures Numpy does not get automatically upgraded.
     - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL scipy matplotlib; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL https://github.com/timj/starlink-pyast/archive/master.zip; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $PYAST == yes ]]; then $PIP_INSTALL https://github.com/timj/starlink-pyast/archive/master.zip; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -8,6 +8,8 @@ be removed in affiliated packages.
 - Changed order of exclusion in MANIFEST.in, excluding *.pyc *after* including
   astropy-template
 
+- Updated astropy-helpers to v0.4.3
+
 0.4 (2014-08-14)
 ----------------
 

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -2,8 +2,13 @@ This file keeps track of changes between tagged versions of the Astropy
 package template, for the benefit of affiliated package maintainers. It can
 be removed in affiliated packages.
 
-0.4.1 (untagged)
+0.4.2 (untagged)
 ----------------
+
+- No changes yet
+
+0.4.1 (2014-10-22)
+------------------
 
 - Changed order of exclusion in MANIFEST.in, excluding *.pyc *after* including
   astropy-template

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -1,4 +1,4 @@
-This file keeps tracbk of changes between tagged versions of the Astropy
+This file keeps track of changes between tagged versions of the Astropy
 package template, for the benefit of affiliated package maintainers. It can
 be removed in affiliated packages.
 

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -190,17 +190,17 @@ def use_astropy_helpers(path=None, download_if_needed=None, index_url=None,
     if index_url is None:
         index_url = INDEX_URL
 
-    if use_git is None:
-        use_git = USE_GIT
-
-    if auto_upgrade is None:
-        auto_upgrade = AUTO_UPGRADE
-
     # If this is a release then the .git directory will not exist so we
     # should not use git.
     git_dir_exists = os.path.exists(os.path.join(os.path.dirname(__file__), '.git'))
     if use_git is None and not git_dir_exists:
         use_git = False
+
+    if use_git is None:
+        use_git = USE_GIT
+
+    if auto_upgrade is None:
+        auto_upgrade = AUTO_UPGRADE
 
     # Declared as False by default--later we check if astropy-helpers can be
     # upgraded from PyPI, but only if not using a source distribution (as in

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -94,6 +94,16 @@ from setuptools import Distribution
 from setuptools.package_index import PackageIndex
 from setuptools.sandbox import run_setup
 
+# Note: The following import is required as a workaround to
+# https://github.com/astropy/astropy-helpers/issues/89; if we don't import this
+# module now, it will get cleaned up after `run_setup` is called, but that will
+# later cause the TemporaryDirectory class defined in it to stop working when
+# used later on by setuptools
+try:
+    import setuptools.py31compat
+except ImportError:
+    pass
+
 # TODO: Maybe enable checking for a specific version of astropy_helpers?
 DIST_NAME = 'astropy-helpers'
 PACKAGE_NAME = 'astropy_helpers'
@@ -185,6 +195,12 @@ def use_astropy_helpers(path=None, download_if_needed=None, index_url=None,
 
     if auto_upgrade is None:
         auto_upgrade = AUTO_UPGRADE
+
+    # If this is a release then the .git directory will not exist so we
+    # should not use git.
+    git_dir_exists = os.path.exists(os.path.join(os.path.dirname(__file__), '.git'))
+    if use_git is None and not git_dir_exists:
+        use_git = False
 
     # Declared as False by default--later we check if astropy-helpers can be
     # upgraded from PyPI, but only if not using a source distribution (as in


### PR DESCRIPTION
I get errors when I try to run `python setup.py test` or `python setup.py build`:
https://gist.github.com/cdeil/121d7d90003d627f0613

@keflavich Do you want to make this an affiliated Astropy package and maintain it, or would it maybe make sense to combine this with [python-reprojection](https://github.com/astrofrog/python-reprojection)?

cc @astrofrog
