### PR TITLE
Sphinx warnings: automodapi problems?

### DIFF
--- a/FITS_tools/cube_regrid.py
+++ b/FITS_tools/cube_regrid.py
@@ -7,7 +7,7 @@ import warnings
 from astropy.convolution import Gaussian2DKernel,Gaussian1DKernel
 import itertools
 import copy
-from contextlib import contextmanager
+import contextlib
 import __builtin__
 from astropy import log
 
@@ -17,11 +17,10 @@ from .hcongrid import get_pixel_mapping
 from .strip_headers import flatten_header
 from .load_header import load_header,get_cd
 
-spectral_smooth_cube__all__ = ["downsample_cube", "get_cube_mapping",
-                               "gsmooth_cube", "regrid_cube",
-                               "regrid_cube_hdu", "regrid_fits_cube",
-                               "smoothing_kernel_size", "spatial_smooth_cube",
-                               ]
+__all__ = ["downsample_cube", "get_cube_mapping", "gsmooth_cube",
+           "regrid_cube", "regrid_cube_hdu", "regrid_fits_cube",
+           "smoothing_kernel_size", "spatial_smooth_cube",
+           'spectral_smooth_cube', 'find_grid_limits']
 
 def regrid_fits_cube(cubefilename, outheader, hdu=0, outfilename=None,
                      clobber=False, **kwargs):
@@ -436,7 +435,7 @@ def downsample_cube(cubehdu, factor, spectralaxis=None):
     return hdu
 
 
-@contextmanager
+@contextlib.contextmanager
 def _map_context(numcores):
     if numcores is not None and numcores > 1:
         try:

--- a/FITS_tools/hcongrid.py
+++ b/FITS_tools/hcongrid.py
@@ -4,6 +4,8 @@ import astropy.wcs as pywcs
 from astropy import coordinates
 from astropy import units as u
 
+__doctest_skip__ = ['hcongrid']
+
 try:
     import scipy.ndimage
 
@@ -37,10 +39,9 @@ try:
 
         Examples
         --------
-        (not written with >>> because test.fits/test2.fits do not exist)
-        fits1 = pyfits.open('test.fits')
-        target_header = pyfits.getheader('test2.fits')
-        new_image = hcongrid(fits1[0].data, fits1[0].header, target_header)
+        >>> fits1 = pyfits.open('test.fits')
+        >>> target_header = pyfits.getheader('test2.fits')
+        >>> new_image = hcongrid(fits1[0].data, fits1[0].header, target_header)
 
         """
     
@@ -108,8 +109,9 @@ try:
 
         Raises
         ------
-        TypeError if either header is not a Header or WCS instance
-        NotImplementedError if the CTYPE in the header is not recognized
+        TypeError :
+            If either header is not a Header or WCS instance
+            NotImplementedError if the CTYPE in the header is not recognized
         """
 
         wcs1 = _load_wcs_from_header(header1)

--- a/FITS_tools/header_tools.py
+++ b/FITS_tools/header_tools.py
@@ -8,6 +8,9 @@ from astropy import log
 from .load_header import get_cd
 from .hcongrid import _ctype_to_csys
 
+__all__ = ["enclosing_header", "header_to_platescale", "smoothing_kernel_size",
+           "wcs_to_platescale",]
+
 def header_to_platescale(header, **kwargs):
     """
     Attempt to determine the spatial platescale from a

--- a/FITS_tools/match_images.py
+++ b/FITS_tools/match_images.py
@@ -5,6 +5,9 @@ from .strip_headers import flatten_header
 from .cube_regrid import regrid_cube_hdu
 from .load_header import load_header
 
+__all__ = ['match_fits', 'match_fits_cubes', 'project_to_header']
+
+
 def project_to_header(fitsfile, header, use_montage=True, quiet=True,
                       **kwargs):
     """

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,9 +5,8 @@ This is an affiliated package for the AstroPy package. The documentation for
 this package is here:
 
 .. toctree::
-  :maxdepth: 2
+  :maxdepth: 1
 
-  packagename/index.rst
   fits_tools.rst
 
 .. note:: Do not edit this page - instead, place all documentation for the


### PR DESCRIPTION
Looks a lot like https://github.com/astrofrog/wcsaxes/issues/79.  I don't understand how https://github.com/astrofrog/wcsaxes/pull/83 fixed it.  @cdeil, any tips, since you seem to be the sphinx guru?

```
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.contextmanager'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.convolve'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.convolve_fft'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.downsample_axis'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.flatten_header'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.get_cd'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.get_pixel_mapping'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.get_spectral_mapping'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.load_header'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.match_images.flatten_header'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.match_images.load_header'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.match_images.regrid_cube_hdu'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.header_tools.get_cd'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.contextmanager'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.convolve'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.convolve_fft'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.downsample_axis'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.flatten_header'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.get_cd'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.get_pixel_mapping'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.get_spectral_mapping'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.cube_regrid.load_header'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.match_images.flatten_header'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.match_images.load_header'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.match_images.regrid_cube_hdu'
None:None: WARNING: toctree contains reference to nonexisting document u'api/FITS_tools.header_tools.get_cd'
```
