### PR TITLE
Addressed deprecated 'update_default_config'

### DIFF
--- a/FITS_tools/__init__.py
+++ b/FITS_tools/__init__.py
@@ -28,6 +28,10 @@ if not _ASTROPY_SETUP_:
                     "importing from source, this is expected.")
             warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
             del e
+        except AttributeError as e:
+            wmsg = (e.args[0] + ", which has been deprecated in astropy 6.1.1.")
+            warn(wmsg)
+            del e
 
     del os, warn, config_dir  # clean up namespace
 


### PR DESCRIPTION
Added an except clause to address the fact that 'update_default_config' has been deprecated in astropy 6.1.1., as per issue https://github.com/keflavich/FITS_tools/issues/15.

